### PR TITLE
Changed amount for raise action to reflect prior action

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/convert-mavens-hh.iml
+++ b/.idea/convert-mavens-hh.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/convert-mavens-hh.iml" filepath="$PROJECT_DIR$/.idea/convert-mavens-hh.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/convertMavensHH.py
+++ b/convertMavensHH.py
@@ -25,6 +25,7 @@
 # 2020-05-12 first version
 # 2020-11-28 fixes for first import (always include showdown round 4)
 # 2020-11-28 make external configuration file
+# 2020-12-21 v 0.1.1 - important bug fix for re-raises
 
 
 import argparse
@@ -36,7 +37,7 @@ import re
 import sys
 
 # constants - DO NOT CHANGE
-VERSION = "0.1"
+VERSION = "0.1.1"
 OPTIONS_FILE = "convertMavensHH.ini"
 INDEX = "index"
 TEXT = "text"


### PR DESCRIPTION
The spec is calling for any action to indicate what is new going into the pot on that action. So a raise should reflect any prior amount committed by the player.  We keep track of that with a new roundCommit dictionary